### PR TITLE
Fix id_lookup() call bug.

### DIFF
--- a/lib/names.c
+++ b/lib/names.c
@@ -166,7 +166,7 @@ pci_lookup_name(struct pci_access *a, char *buf, int size, int flags, ...)
       id = va_arg(args, int);
       isv = va_arg(args, int);
       isd = va_arg(args, int);
-      v = id_lookup(a, flags, ID_VENDOR, isv, 0, 0, 0);
+      v = id_lookup(a, flags, ID_VENDOR, iv, 0, 0, 0);
       d = id_lookup_subsys(a, flags, iv, id, isv, isd);
       sprintf(numbuf, "%04x:%04x", isv, isd);
       return format_name_pair(buf, size, flags, v, d, numbuf);


### PR DESCRIPTION
This pci.ids would previously fail, with this fix works:

10ee  Xilinx Corporation
	7011  Kintex 7 Designs (Xilinx IP)
		1a3e 132c  MRF EVR-300DC [MicroTCA event receiver]